### PR TITLE
Update: Anchor MonoBehaviour

### DIFF
--- a/Runtime/Anchor.cs
+++ b/Runtime/Anchor.cs
@@ -80,18 +80,15 @@ namespace Tesrym.AnchorSystem {
         private void OnEnable() {
             Instance = this;
             Run();
-
         }
 
-        private void LateUpdate() {
+        private void FixedUpdate() {
             Run();
-
         }
 
         private void OnDisable() {
             Stop();
             Instance = null;
-
         }
 
         private void OnDrawGizmos() {


### PR DESCRIPTION
Change the run from lifecycle LateUpdate to FixedUpdate to prevent some physics movement error.